### PR TITLE
Adjust z-index to keep user marker from overlapping shop markers if both are same coordinates.

### DIFF
--- a/frontend/src/app/home/map/map.component.ts
+++ b/frontend/src/app/home/map/map.component.ts
@@ -136,7 +136,8 @@ export class MapComponent implements OnInit {
     coordinates.forEach((coord) => {
       const userMarkerOptions: CustomMarkerOptions = {
         icon: this.geolocationService.getUserMarkerIcon(),
-        isCurrentUser: true
+        isCurrentUser: true,
+        zIndexOffset: -100
       };
 
       const userMarker = marker([coord[0], coord[1]], userMarkerOptions)


### PR DESCRIPTION
[See commit]